### PR TITLE
Reduce python package caching.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,14 +3,14 @@ name: Docker Image CI
 on: [push]
 
 jobs:
-
   build:
- 
     runs-on: ubuntu-latest
- 
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag nimbusml --tag nimbusml:$(date +%s)
-    - name: Test the Docker image
-      run: docker run --rm -t nimbusml
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag nimbusml --tag nimbusml:$(date +%s)
+      - name: Docker image details
+        run: docker image ls
+      - name: Test the Docker image
+        run: docker run --rm -t nimbusml

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,7 +22,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: docker://github/super-linter:latest
+        uses: docker://github/super-linter:v2.1.0
         env:
           VALIDATE_ALL_CODEBASE: true
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,7 +7,7 @@ name: Lint Code Base
 on:
   push:
     branches-ignore:
-      - 'master'
+      - "master"
 
 jobs:
   build:
@@ -25,4 +25,3 @@ jobs:
         uses: docker://github/super-linter:v2.1.0
         env:
           VALIDATE_ALL_CODEBASE: true
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ## Build with command [from repo root directory]:
-# docker build --tag jthelin/nimbusml . --file ./Dockerfile
+# docker build --tag nimbusml . --file ./Dockerfile
 ##
 ## Run with command:
-# docker run --rm -it jthelin/nimbusml bash
+# docker run --rm -it nimbusml bash
 ##
 
 # Based on:
@@ -25,14 +25,25 @@ RUN apt-get update --quiet \
 RUN ln -s /usr/bin/python3 /usr/local/bin/python \
  && ln -s /usr/bin/pip3 /usr/local/bin/pip
 
+# Show installed versions of python and pip
 RUN command -v python && command -v pip && python --version
+
 RUN pip install --no-cache-dir --upgrade pip setuptools
 
-# Install extra python package dependencies.
-RUN pip install distro dotnetcore2 numpy pandas pytz python-dateutil scikit-learn scipy six
+# Pre-install extra python package dependencies (to allow docker layer reuse).
+RUN pip install --no-cache-dir \
+       distro \
+       dotnetcore2 \
+       numpy \
+       pandas \
+       pytz \
+       python-dateutil \
+       scikit-learn \
+       scipy \
+       six
 
-# Install MimbusML python package.
-RUN pip install nimbusml
+# Install NimbusML python package.
+RUN pip install --no-cache-dir nimbusml==1.8.0
 
 # Set the working directory
 RUN mkdir -p /datadrive && mkdir -p /home/app/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@
 
 FROM nvidia/cuda:10.2-cudnn7-devel
 
+ENV NIMBUSML_VERSION=1.8.0
+
 # Install extra package dependencies.
 RUN apt-get update --quiet \
  && apt-get install --yes --no-install-recommends --quiet \
@@ -43,7 +45,7 @@ RUN pip install --no-cache-dir \
        six
 
 # Install NimbusML python package.
-RUN pip install --no-cache-dir nimbusml==1.8.0
+RUN pip install --no-cache-dir nimbusml==${NIMBUSML_VERSION}
 
 # Set the working directory
 RUN mkdir -p /datadrive && mkdir -p /home/app/src


### PR DESCRIPTION
- Use `--no-cache-dir` when installing python pip packages, to reduce docker image side by ~210MB.

- Use explicit version numbers for `nimbusml` python package, so that Dependabot can check for & handle version upgrades.